### PR TITLE
Backtrace function

### DIFF
--- a/kernel/CUtils/assert.h
+++ b/kernel/CUtils/assert.h
@@ -11,10 +11,12 @@
 #define _ASSERT_H_
 
 #include "stdio.h"
+#include "backtrace.h"
 
 #define assert(cond)    do {                                                                                                            \
                                 if (!(cond)) {                                                                                          \
                                         printf("%s (%s:%d): Assertion \"%s\" failed.", __FILE__, __func__, __LINE__, #cond);            \
+                                        backtrace_print();                                                                              \
                                 }                                                                                                       \
                         } while (0)
 

--- a/kernel/CUtils/backtrace.c
+++ b/kernel/CUtils/backtrace.c
@@ -1,0 +1,16 @@
+#include "backtrace.h"
+#include "stdio.h"
+
+#define BACKTRACE_SIZE 10
+static void *backtrace_buffer[BACKTRACE_SIZE];
+
+void backtrace_print(void)
+{
+        int i;
+
+        backtrace(backtrace_buffer, BACKTRACE_SIZE);
+        for (i = 0; i < BACKTRACE_SIZE; ++i) {
+                printf("%3d: 0x%08x\n", i backtrace_buffer[i]);
+        }
+}
+

--- a/kernel/CUtils/backtrace.h
+++ b/kernel/CUtils/backtrace.h
@@ -1,0 +1,27 @@
+/*
+ * backtrace.h
+ *
+ * Copyright (C) 2012 Simple Object Kernel project
+ * by Gaëtan Morin
+ *
+ * Backtrace Headers.
+ */
+
+#ifndef _BACKTRACE_H_
+#define _BACKTRACE_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+
+void backtrace(void **array, int size);
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/kernel/CUtils/backtrace.h
+++ b/kernel/CUtils/backtrace.h
@@ -17,6 +17,7 @@ extern "C" {
 
 
 void backtrace(void **array, int size);
+void backtrace_print(void);
 
 
 

--- a/kernel/CUtils/backtrace.s
+++ b/kernel/CUtils/backtrace.s
@@ -1,0 +1,60 @@
+#
+# backtrace.s
+#
+# Copyright (C) 2012 Simple Object Kernel project
+# by Gaëtan Morin
+#
+# x86 (32bit) implementation of backtrace.
+#
+#
+# ---
+#
+# The idea behind this algorithm to follow the linked list formed by the base
+# pointers pushed at the beginning of each stack frame when a function is
+# entered. We assume that the word just before the base pointer in the stack
+# is indeed the return address to the caller and write that in the back trace.
+#
+# WARNING:
+# Currently this code is not able to exit early when the end of the stack is
+# reached. This means that if you call backtrace with a `size` parameter larger
+# than the total number of stack frames at the time of the call, this code WILL
+# segfault or do somthing bad.
+#
+
+
+.globl backtrace
+
+
+backtrace:                              # backtrace(void **array, int size)
+    pushl   %ebp
+    movl    %esp, %ebp
+    
+    movl    8(%ebp), %ecx               # %ecx = array
+    movl    12(%ebp), %edx              # %edx = size
+    leal    (%ecx, %edx, 4), %edx       # %edx = &array[size]
+
+backtrace.loop:
+    # Exit when %ecx == %edx (ie. we wrote `size` entries into array)
+    #
+    cmpl    %ecx, %edx
+    je      backtrace.exit
+
+    # At this point:
+    #
+    #               +----------------+
+    #               | RETURN ADDRESS |
+    #               +----------------+
+    #       EBP --> | PREVIOUS FRAME |
+    #               +----------------+
+    #
+    movl    4(%ebp), %eax               # %eax = return address
+    movl    0(%ebp), %ebp               # %ebp = previous frame
+    movl    %eax, (%ecx)                # *(%ecx) = return address
+    addl    $4, %ecx                    # %ecx++
+    jmp     backtrace.loop
+
+backtrace.exit:
+    popl   %ebp
+    ret
+
+


### PR DESCRIPTION
These commits introduce a 'backtrace' implementation for x86. For now there there is no way to find the matching symbols (just the backtrace function as defined in glibc).
