### PR TITLE
Backtrace api change

### DIFF
--- a/kernel/CUtils/backtrace.h
+++ b/kernel/CUtils/backtrace.h
@@ -23,8 +23,10 @@ extern "C" {
  * @param array a pointer array capable of holding at least {@code size}
  *        elements
  * @param size the maximum number of stack frames to unwind
+ * @return the number of entries written into the array (between 0 and
+ *        {@code size}, included).
  */
-void backtrace(void **array, int size);
+int backtrace(void **array, int size);
 
 
 #ifdef __cplusplus

--- a/kernel/CUtils/panic.c
+++ b/kernel/CUtils/panic.c
@@ -19,7 +19,7 @@ __inline__ static void hlt(void)
 void panic(const char *fmt, ...)
 {
         va_list args;
-        int i;
+        int i, max;
         void *addr;
 
         /* Print user message */
@@ -28,15 +28,13 @@ void panic(const char *fmt, ...)
         va_end(args);
 
         /* Get the stack trace */
-        memset(backtrace_buffer, 0, MAX_STACK_TRACE_DEPTH * sizeof(void *));
-        backtrace(backtrace_buffer, MAX_STACK_TRACE_DEPTH);
+        memset(backtrace_buffer, 1, MAX_STACK_TRACE_DEPTH * sizeof(void *));
+        max = backtrace(backtrace_buffer, MAX_STACK_TRACE_DEPTH);
 
         /* Print the stack trace */
-        printf("\nstack trace:");
-        for (i = 0; i < MAX_STACK_TRACE_DEPTH; ++i) {
-                if (!(addr = backtrace_buffer[i])) {
-                        break;
-                }
+        printf("\nstack trace:\n");
+        for (i = 0; i < max; ++i) {
+                addr = backtrace_buffer[i];
                 printf(" %3d: %08x\n", i, (uintptr_t) addr);
         }
 

--- a/kernel/CUtils/x86/backtrace.S
+++ b/kernel/CUtils/x86/backtrace.S
@@ -36,6 +36,8 @@ backtrace:                              # backtrace(void **array, int size)
     movl    12(%ebp), %edx              # %edx = size
     leal    (%ecx, %edx, 4), %edx       # %edx = &array[size]
 
+    pushl   %ecx                        # save array for later use
+
 backtrace.loop:
     # Exit when:
     #   - %ecx == %edx (we wrote `size` entries into array)
@@ -61,7 +63,15 @@ backtrace.loop:
     jmp     backtrace.loop
 
 backtrace.exit:
-    popl   %ebp
+    popl    %edx                        # %edx = array
+    popl    %ebp                        # restore %ebp
+
+    # Return the number of written entries
+    # (difference between %ecx and the array start)
+    #
+    movl    %ecx, %eax
+    subl    %edx, %eax
+    shrl    $2, %eax                    # %eax = (%ecx - %edx) / 4
     ret
 
 


### PR DESCRIPTION
The `backtrace(void **array, int size)` function now returns the number of entries actually written in the array. This is nicer for the caller and it makes the API consistent with [gnulibc's backtrace](http://www.gnu.org/software/libc/manual/html_node/Backtraces.html).
